### PR TITLE
Update .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,5 @@
+/*eslint linebreak-style: ["error", "unix"]*/
+
 {
   "extends": [
     "airbnb",
@@ -14,6 +16,7 @@
     "prettier"
   ],
   "rules": {
+    "linebreak-style": 0,
     "func-names": 0,
     "import/no-extraneous-dependencies": [
       "error",


### PR DESCRIPTION
error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style fix